### PR TITLE
Refresh frames when size changed + prevent retain cycle + destroy

### DIFF
--- a/MYPassthrough.podspec
+++ b/MYPassthrough.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "MYPassthrough"
-  s.version      = "0.5"
+  s.version      = "0.6"
   s.summary      = "Framework that helps you to guide the user through your application, step by step."
   s.description  = <<-DESC
                     With the help of this framework, it will be easier for you to solve such tasks: guide, tutorial, help, onboarding

--- a/Source/PassthroughController.swift
+++ b/Source/PassthroughController.swift
@@ -134,7 +134,7 @@ class PassthroughController: UIViewController, CAAnimationDelegate {
             self.clean()
             self.adjust(with: self.emptyPath, animated: false)
         }) { [unowned self] _ in
-            self.orientationDidChange()
+            self.orientationDidChange(newSize: size)
         }
     }
 
@@ -143,11 +143,12 @@ class PassthroughController: UIViewController, CAAnimationDelegate {
     @objc func tapAction() {
         didTapAction?()
     }
-    
-    func orientationDidChange() {
+
+    func orientationDidChange(newSize: CGSize) {
         guard let currentOrientation = PassthroughOrientation(UIDevice.current.orientation) else { return }
-        guard lastOrientation != currentOrientation else { return }
+        guard lastOrientation != currentOrientation || lastSize != newSize else { return }
         didOrientationChange?()
+        lastSize = newSize
         lastOrientation = currentOrientation
     }
 

--- a/Source/PassthroughController.swift
+++ b/Source/PassthroughController.swift
@@ -9,21 +9,22 @@
 import UIKit
 
 class PassthroughController: UIViewController, CAAnimationDelegate {
-    
     private var mask = CAShapeLayer()
     private var frameInset: CGFloat {
         return -max(view.frame.width, view.frame.height)
     }
+
     private var initialPath: UIBezierPath {
         let fullFrame = UIBezierPath(rect: view.frame.insetBy(dx: frameInset, dy: frameInset))
         let cutFrame = UIBezierPath(roundedRect: view.frame.insetBy(dx: frameInset / 2, dy: frameInset / 2), cornerRadius: 30)
         fullFrame.append(cutFrame)
         return fullFrame
     }
-    
+
     var emptyPath: UIBezierPath {
         return UIBezierPath(rect: view.frame.insetBy(dx: frameInset, dy: frameInset))
     }
+
     var animationDuration: CFTimeInterval = 0.5
     var closeButton = CloseButton(frame: CGRect.zero)
     var maskFillColor: UIColor! {
@@ -31,43 +32,46 @@ class PassthroughController: UIViewController, CAAnimationDelegate {
             mask.fillColor = maskFillColor.cgColor
         }
     }
-    var demonastrationView: UIView!
+
+    var demonstrationView: UIView!
     override var preferredStatusBarStyle: UIStatusBarStyle {
         return .lightContent
     }
+
     private var tapGestureRecognizer: UITapGestureRecognizer!
     private var lastOrientation: PassthroughOrientation?
-    
+    private var lastSize: CGSize?
+
     // MARK: - Events
-    
-    var didTapAction:(() -> Void)?
-    var didCancelAction:(() -> Void)?
-    var didOrientationChange:(() -> Void)?
-    var didFinishedAnimation:(() -> Void)?
+
+    var didTapAction: (() -> Void)?
+    var didCancelAction: (() -> Void)?
+    var didOrientationChange: (() -> Void)?
+    var didFinishedAnimation: (() -> Void)?
     var didChangeState: ((PassthroughState) -> Void)?
 
     override func viewDidLoad() {
         super.viewDidLoad()
         didChangeState?(.initialization)
-        configDemonastrationView()
+        configDemonstrationView()
         configCloseButton()
 
-        tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(PassthroughController.tapAction))
+        tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(tapAction))
         view.addGestureRecognizer(tapGestureRecognizer)
     }
-    
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         didChangeState?(.demonstration)
     }
-    
+
     func setupInitialMask(withColor color: UIColor) {
         mask.fillRule = .evenOdd
         mask.fillColor = color.cgColor
         view.layer.addSublayer(mask)
         mask.path = initialPath.cgPath
     }
-    
+
     func prepareToDemonstration() {
         lastOrientation = PassthroughOrientation(UIDevice.current.orientation)
         tapGestureRecognizer.isEnabled = true
@@ -87,14 +91,14 @@ class PassthroughController: UIViewController, CAAnimationDelegate {
         } else {
             mask.removeAnimation(forKey: "path")
         }
-        
+
         mask.path = overlayPath.cgPath
     }
-    
+
     func clean() {
-        demonastrationView.subviews.forEach { $0.removeFromSuperview() }
+        demonstrationView.subviews.forEach { $0.removeFromSuperview() }
     }
-    
+
     func finishDemonstration() {
         tapGestureRecognizer.isEnabled = false
         clean()
@@ -105,15 +109,15 @@ class PassthroughController: UIViewController, CAAnimationDelegate {
     }
 
     // MARK: - Private
-    
-    private func configDemonastrationView() {
-        let demonastrationView = UIView(frame: view.bounds)
-        demonastrationView.backgroundColor = UIColor.clear
-        demonastrationView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-        view.addSubview(demonastrationView)
-        self.demonastrationView = demonastrationView
+
+    private func configDemonstrationView() {
+        let demonstrationView = UIView(frame: view.bounds)
+        demonstrationView.backgroundColor = UIColor.clear
+        demonstrationView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        view.addSubview(demonstrationView)
+        self.demonstrationView = demonstrationView
     }
-    
+
     private func configCloseButton() {
         closeButton.alpha = 0.0
         view.addSubview(closeButton)
@@ -122,9 +126,9 @@ class PassthroughController: UIViewController, CAAnimationDelegate {
             self?.didCancelAction?()
         }
     }
-    
+
     // MARK: - Orientation
-    
+
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         coordinator.animate(alongsideTransition: { [unowned self] _ in
             self.clean()
@@ -133,9 +137,9 @@ class PassthroughController: UIViewController, CAAnimationDelegate {
             self.orientationDidChange()
         }
     }
-    
+
     // MARK: - Action
-    
+
     @objc func tapAction() {
         didTapAction?()
     }
@@ -148,10 +152,10 @@ class PassthroughController: UIViewController, CAAnimationDelegate {
     }
 
     // MARK: - CAAnimationDelegate
-    
+
     func animationDidStop(_ anim: CAAnimation, finished flag: Bool) {
         if flag {
-           didFinishedAnimation?()
+            didFinishedAnimation?()
         }
     }
 }

--- a/Source/PassthroughController.swift
+++ b/Source/PassthroughController.swift
@@ -26,7 +26,7 @@ class PassthroughController: UIViewController, CAAnimationDelegate {
     }
 
     var animationDuration: CFTimeInterval = 0.5
-    var closeButton = CloseButton(frame: CGRect.zero)
+    var closeButton = CloseButton(frame: .zero)
     var maskFillColor: UIColor! {
         didSet {
             mask.fillColor = maskFillColor.cgColor
@@ -83,7 +83,7 @@ class PassthroughController: UIViewController, CAAnimationDelegate {
             anim.timingFunction = CAMediaTimingFunction(name: .easeOut)
             anim.duration = animationDuration
             anim.delegate = self
-            anim.isRemovedOnCompletion = false
+            anim.isRemovedOnCompletion = true
             anim.fillMode = .forwards
             anim.fromValue = mask.path
             anim.toValue = overlayPath.cgPath

--- a/Source/PassthroughEntities.swift
+++ b/Source/PassthroughEntities.swift
@@ -23,7 +23,7 @@ public enum PassthroughOrientation: Int {
     case any
     case portrait
     case landscape
-    
+
     init?(_ orientation: UIDeviceOrientation) {
         switch orientation {
         case .landscapeLeft, .landscapeRight:
@@ -41,7 +41,7 @@ public enum ButtonPosition: Equatable {
     case bottomRight(xMargin: CGFloat, yMargin: CGFloat)
     case topLeft(xMargin: CGFloat, yMargin: CGFloat)
     case topRight(xMargin: CGFloat, yMargin: CGFloat)
-    
+
     public static func == (lhs: ButtonPosition, rhs: ButtonPosition) -> Bool {
         switch (lhs, rhs) {
         case (.bottomLeft(let lhsxMargin, let lhsyMargin), .bottomLeft(let rhsxMargin, let rhsyMargin)):
@@ -80,7 +80,7 @@ public struct PassthroughTask {
     public var infoDescriptor: InfoDescriptor?
     public var didFinishTask: (() -> Void)?
     public var orientationDidChange: (() -> Void)?
-    
+
     public init(with holeDescriptors: [HoleDescriptor]) {
         self.holeDescriptors = holeDescriptors
     }
@@ -90,16 +90,16 @@ open class CloseButton: UIButton {
     public var closeButtonPosition: ButtonPosition? {
         return position
     }
-    
+
     var position: ButtonPosition?
     var touchUpInsideHandler: (() -> Void)?
-    
+
     public override init(frame: CGRect) {
         super.init(frame: frame)
         addTarget(self, action: #selector(touchUpInsideAction), for: .touchUpInside)
-        self.configureAppearance()
+        configureAppearance()
     }
-    
+
     public required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -107,9 +107,9 @@ open class CloseButton: UIButton {
     @objc func touchUpInsideAction() {
         touchUpInsideHandler?()
     }
-    
+
     // MARK: - Private
-    
+
     private func configureAppearance() {
         tintColor = UIColor.white
         titleLabel?.textColor = UIColor.white
@@ -123,13 +123,13 @@ open class HoleDescriptor: HoleLocation {
     public let type: HoleType
     public let frame: CGRect
     public let orientation: PassthroughOrientation
-    
+
     public init(frame: CGRect, type: HoleType, forOrientation orientation: PassthroughOrientation) {
         self.frame = frame.integral
         self.type = type
         self.orientation = orientation
     }
-    
+
     func frame(forParentView parentView: UIView, inOrientation orientation: UIDeviceOrientation) -> CGRect? {
         switch self.orientation {
         case .any:
@@ -146,24 +146,24 @@ open class HoleViewDescriptor: HoleDescriptor {
     public let view: UIView
     public let paddingX: CGFloat
     public let paddingY: CGFloat
-    
+
     public init(view: UIView, paddingX: CGFloat, paddingY: CGFloat, type: HoleType, forOrientation orientation: PassthroughOrientation) {
         self.view = view
         self.paddingX = paddingX
         self.paddingY = paddingY
         let highlightedFrame = view.frame.insetBy(dx: -paddingX, dy: -paddingY)
-        
+
         super.init(frame: highlightedFrame, type: type, forOrientation: orientation)
     }
-    
+
     public convenience init(view: UIView, type: HoleType) {
         self.init(view: view, paddingX: 0, paddingY: 0, type: type, forOrientation: .any)
     }
-    
+
     public convenience init(view: UIView, type: HoleType, forOrientation orientation: PassthroughOrientation) {
         self.init(view: view, paddingX: 0, paddingY: 0, type: type, forOrientation: orientation)
     }
-    
+
     override func frame(forParentView parentView: UIView, inOrientation orientation: UIDeviceOrientation) -> CGRect? {
         let convertedFrame = view.superview?.convert(view.frame, to: parentView)
         let highlightedFrame = convertedFrame?.insetBy(dx: -paddingX, dy: -paddingY).integral
@@ -180,23 +180,21 @@ open class HoleViewDescriptor: HoleDescriptor {
 }
 
 open class CellViewDescriptor: HoleDescriptor {
-    
     public let indexPath: IndexPath
     public let tableView: UITableView
-    
+
     public init(tableView: UITableView, indexPath: IndexPath, forOrientation orientation: PassthroughOrientation) {
         self.tableView = tableView
         self.indexPath = indexPath
         let highlightedFrame = tableView.cellForRow(at: indexPath)?.frame ?? CGRect.zero
-        
+
         super.init(frame: highlightedFrame, type: .rect(cornerRadius: 5, margin: 0), forOrientation: orientation)
     }
-    
+
     override func frame(forParentView parentView: UIView, inOrientation orientation: UIDeviceOrientation) -> CGRect? {
-        
         guard let cell = tableView.cellForRow(at: indexPath) else { return nil }
         let highlightedFrame = cell.superview?.convert(cell.frame, to: parentView)
-        
+
         switch self.orientation {
         case .any:
             return highlightedFrame
@@ -218,14 +216,14 @@ open class Descriptor {
     public let text: String
     public var aligment: LabelAligment = .center
     public var widthControl: WidthControl = .ratio(0.7)
-    
+
     init(for text: String) {
         self.text = text
         initialSetup()
     }
-    
+
     // MARK: Private
-    
+
     private func initialSetup() {
         label.backgroundColor = UIColor.clear
         label.textColor = UIColor.white
@@ -239,7 +237,7 @@ open class Descriptor {
 open class LabelDescriptor: Descriptor {
     public var position: LabelPosition = .bottom
     public var margin: CGFloat = 20
-    
+
     public override init(for text: String) {
         super.init(for: text)
         PassthroughManager.shared.labelCommonConfigurator?(self)
@@ -248,7 +246,7 @@ open class LabelDescriptor: Descriptor {
 
 open class InfoDescriptor: Descriptor {
     public var offset = CGPoint.zero
-    
+
     public override init(for text: String) {
         super.init(for: text)
         PassthroughManager.shared.infoCommonConfigurator?(self)

--- a/Source/PassthroughManager.swift
+++ b/Source/PassthroughManager.swift
@@ -9,40 +9,42 @@
 import UIKit
 
 open class PassthroughManager {
-
     public static let shared = PassthroughManager()
-    
+
     public var bottomOffset: CGFloat = 40
     public var topOffset: CGFloat = 40
-    public var dimColor = UIColor.black.withAlphaComponent(0.7) {
+    public var dimColor = UIColor.black.withAlphaComponent(0.8) {
         didSet {
             passthroughRootController.maskFillColor = dimColor
         }
     }
+
     public var closeButton: CloseButton {
         return passthroughRootController.closeButton
     }
-    
+
     public var animationDuration: CFTimeInterval {
         get {
-           return passthroughRootController.animationDuration
+            return passthroughRootController.animationDuration
         }
         set {
-           passthroughRootController.animationDuration = newValue
+            passthroughRootController.animationDuration = newValue
         }
     }
+
     public var state: PassthroughState {
         return currentState
     }
-    
+
     public var infoCommonConfigurator: ((InfoDescriptor) -> Void)?
     public var labelCommonConfigurator: ((LabelDescriptor) -> Void)?
-    
+
     private var mainView: UIView {
         return passthroughRootController.view
     }
-    private var demonastrationView: UIView {
-        return passthroughRootController.demonastrationView
+
+    private var demonstrationView: UIView {
+        return passthroughRootController.demonstrationView
     }
 
     private var currentState: PassthroughState = .loaded {
@@ -59,46 +61,46 @@ open class PassthroughManager {
             }
         }
     }
-    
-    private var passthroughWindow: UIWindow
-    private var passthroughRootController: PassthroughController
+
+    private var passthroughWindow: UIWindow!
+    private var passthroughRootController: PassthroughController!
     private var tasks: [PassthroughTask] = []
     private var currentTaskIndex: Int = 0
     private var completion: ((Bool) -> Swift.Void)?
     private var isUserCancel: Bool = false
-        
+
     private init() {
         let passthroughWindow = UIWindow(frame: UIScreen.main.bounds)
-        passthroughWindow.backgroundColor = UIColor.clear
+        passthroughWindow.backgroundColor = .clear
         passthroughWindow.autoresizingMask = [.flexibleHeight, .flexibleWidth]
         passthroughWindow.windowLevel = .alert
         self.passthroughWindow = passthroughWindow
-        self.passthroughRootController = PassthroughController()
-        
+        passthroughRootController = PassthroughController()
+
         bindRootController()
     }
-    
+
     // MARK: - Public
-    
+
     public func display(tasks: [PassthroughTask], completion: ((Bool) -> Swift.Void)? = nil) {
         guard !tasks.isEmpty else { return }
-        
+
         passthroughWindow.isHidden = false
-        passthroughWindow.rootViewController = self.passthroughRootController
+        passthroughWindow.rootViewController = passthroughRootController
         passthroughWindow.windowLevel = .normal + 1
         passthroughWindow.rootViewController?.view.frame = passthroughWindow.frame
         self.tasks = tasks
         self.completion = completion
     }
-    
+
     public func hide() {
         guard currentState == .demonstration else { return }
         isUserCancel = true
         finishDemonstration()
     }
-    
+
     // MARK: - Private
-    
+
     private func bindRootController() {
         passthroughRootController.didTapAction = {
             [weak self] in
@@ -108,13 +110,14 @@ open class PassthroughManager {
             sSelf.currentTaskIndex += 1
             sSelf.handleTask(for: sSelf.currentTaskIndex)
         }
+
         passthroughRootController.didCancelAction = {
             [weak self] in
             guard let sSelf = self else { return }
             sSelf.isUserCancel = true
             sSelf.finishDemonstration()
         }
-        
+
         passthroughRootController.didOrientationChange = {
             [weak self] in
             guard let sSelf = self else { return }
@@ -126,7 +129,7 @@ open class PassthroughManager {
             sSelf.passthroughRootController.adjust(with: overlayPath, animated: false)
             sSelf.handleTask(for: sSelf.currentTaskIndex)
         }
-        
+
         passthroughRootController.didFinishedAnimation = {
             [weak self] in
             guard let sSelf = self else { return }
@@ -135,12 +138,13 @@ open class PassthroughManager {
                 sSelf.cleanUp()
             }
         }
+
         passthroughRootController.didChangeState = {
             [weak self] state in
             self?.currentState = state
         }
     }
-    
+
     private func handleTask(for index: Int) {
         guard tasks.count > index else {
             finishDemonstration()
@@ -153,11 +157,11 @@ open class PassthroughManager {
         updateLabelsPosition()
         passthroughRootController.adjust(with: overlayPath, animated: true)
     }
-    
+
     private func finishDemonstration() {
         passthroughRootController.finishDemonstration()
     }
-    
+
     private func cleanUp() {
         passthroughWindow.isHidden = true
         passthroughWindow.rootViewController = nil
@@ -183,31 +187,31 @@ open class PassthroughManager {
                     path = UIBezierPath(roundedRect: frame.insetBy(dx: -margin, dy: -margin).integral, cornerRadius: cornerRadius)
                 }
                 overlayPath.append(path)
-                
+
                 calculateLabelPosition(for: frame, withlabelDescriptor: descriptor.labelDescriptor)
             }
         }
-        
+
         return overlayPath
     }
-    
+
     private func startAnimatioRect(for rect: CGRect) -> CGRect {
         return CGRect(x: rect.midX - 2, y: rect.midY - 2, width: 4, height: 4).integral
     }
-    
+
     private func didFinishTask(at index: Int) {
         let task = tasks[index]
         task.didFinishTask?()
     }
-    
+
     private func calculateClosePosition(for task: PassthroughTask) {
         if task.closeButtonPosition != closeButton.position {
             closeButton.alpha = 0.0
-            
+
             let bounds = mainView.bounds
             var x: CGFloat = 0
             var y: CGFloat = 0
-            
+
             switch task.closeButtonPosition {
             case .bottomLeft(let xMargin, let yMargin):
                 closeButton.position = .bottomLeft(xMargin: xMargin, yMargin: yMargin)
@@ -226,19 +230,19 @@ open class PassthroughManager {
                 x = bounds.width - xMargin - closeButton.frame.width
                 y = yMargin
             }
-            
+
             closeButton.frame.origin = CGPoint(x: x, y: y)
-            
+
             UIView.animate(withDuration: animationDuration) { [weak self] in
                 self?.closeButton.alpha = 1.0
             }
         }
     }
-    
+
     private func configLabel(with descriptor: Descriptor) -> UILabel {
         let bounds = mainView.bounds
         let label = descriptor.label
-        demonastrationView.addSubview(label)
+        demonstrationView.addSubview(label)
         label.alpha = 0.0
         switch descriptor.widthControl {
         case .precise(let value):
@@ -248,7 +252,7 @@ open class PassthroughManager {
         }
         label.text = descriptor.text
         label.sizeToFit()
-        
+
         return label
     }
 
@@ -256,10 +260,10 @@ open class PassthroughManager {
         guard let labelDescriptor = labelDescriptor else { return }
         let bounds = mainView.bounds
         let label = configLabel(with: labelDescriptor)
-        
+
         var x: CGFloat = 0
         var y: CGFloat = 0
-        
+
         switch labelDescriptor.aligment {
         case .right:
             x = bounds.width - label.frame.width - labelDescriptor.margin
@@ -267,13 +271,12 @@ open class PassthroughManager {
             x = (bounds.width - label.frame.width) / 2
         case .left:
             x = labelDescriptor.margin
-            
         }
-        
+
         switch labelDescriptor.position {
         case .top:
             y = overlayRect.origin.y - label.frame.height - labelDescriptor.margin
-            
+
             if y < topOffset {
                 y = overlayRect.origin.y + overlayRect.height + labelDescriptor.margin
             }
@@ -290,18 +293,18 @@ open class PassthroughManager {
             y = overlayRect.origin.y + overlayRect.height / 2 - label.frame.height / 2
             x = overlayRect.origin.x - label.frame.width - labelDescriptor.margin
         }
-        
+
         label.frame.origin = CGPoint(x: x, y: y)
     }
-    
+
     private func calculateLabelPosition(for infoDescriptor: InfoDescriptor?) {
         guard let infoDescriptor = infoDescriptor else { return }
         let bounds = mainView.bounds
         let label = configLabel(with: infoDescriptor)
-        
+
         var x: CGFloat = 0
         var y: CGFloat = 0
-        
+
         switch infoDescriptor.aligment {
         case .right:
             x = bounds.width - label.frame.width - infoDescriptor.offset.x
@@ -310,16 +313,16 @@ open class PassthroughManager {
         case .left:
             x = infoDescriptor.offset.x
         }
-        
+
         y = (bounds.height - label.frame.height) / 2 + infoDescriptor.offset.y
-        
+
         label.frame.origin = CGPoint(x: x, y: y)
     }
-    
+
     private func updateLabelsPosition() {
-        for view in demonastrationView.subviews {
-            UIView.animate(withDuration: animationDuration) {
-                view.alpha = 1.0
+        for view in demonstrationView.subviews {
+            UIView.animate(withDuration: animationDuration) { [weak view] in
+                view?.alpha = 1.0
             }
         }
     }
@@ -333,7 +336,7 @@ private extension UIBezierPath {
         let halfHeight = rect.height / 2
         let radius = sqrt(halfWidth * halfWidth + halfHeight * halfHeight)
         let center = CGPoint(x: rect.midX, y: rect.midY)
-        
+
         self.init(roundedRect: CGRect(x: center.x - radius, y: center.y - radius, width: radius * 2, height: radius * 2).integral, cornerRadius: radius)
     }
 }

--- a/Source/PassthroughManager.swift
+++ b/Source/PassthroughManager.swift
@@ -9,7 +9,19 @@
 import UIKit
 
 open class PassthroughManager {
-    public static let shared = PassthroughManager()
+    private static var sharedInstance: PassthroughManager?
+    public class var shared: PassthroughManager {
+        guard let sharedInstance = self.sharedInstance else {
+            let sharedInstance = PassthroughManager()
+            self.sharedInstance = sharedInstance
+            return sharedInstance
+        }
+        return sharedInstance
+    }
+
+    public class func destroyShared() {
+        sharedInstance = nil
+    }
 
     public var bottomOffset: CGFloat = 40
     public var topOffset: CGFloat = 40


### PR DESCRIPTION
With iPad split screen multitasking we need to refresh frames also if size changed not only on rotation
+
Remove animation on completion to prevent retain cycle
+
Add the possibility to destroy singleton to not keep the passthrough in memory after using it